### PR TITLE
feat: add email field to user profile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1228,6 +1228,7 @@ export class UserProfile {
     public readonly userId: number
     public readonly firstName: string
     public readonly lastName: string
+    public readonly email: string
 
     /**
      * Creates instance of class {@link UserProfile}.
@@ -1239,6 +1240,7 @@ export class UserProfile {
         this.userId = profile.userId
         this.firstName = profile.firstName
         this.lastName = profile.lastName
+        this.email = profile.email
     }
 
     /**
@@ -9112,17 +9114,20 @@ class CoreProfileV1 {
     userId: number
     firstName: string
     lastName: string
+    email: string
 
     constructor(data: {
         result: {
             user_id: number
             first_name: string
             last_name: string
+            email: string
         }
     }) {
         this.userId = data.result.user_id
         this.firstName = data.result.first_name
         this.lastName = data.result.last_name
+        this.email = data.result.email
     }
 }
 

--- a/test/profile.spec.ts
+++ b/test/profile.spec.ts
@@ -1,0 +1,26 @@
+import { ClientSdk } from "../src";
+import { getUserByTitle } from "./utils/userUtils";
+import { User, WS_URL } from "./vars";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getOAuthMethod } from "./utils/authHelper";
+
+describe("userProfile", () => {
+  let sdk: ClientSdk;
+  let user: User;
+
+  beforeAll(async () => {
+    user = getUserByTitle("regular_user") as User;
+    const { oauth, options } = getOAuthMethod(user);
+    sdk = await ClientSdk.create(WS_URL, 82, oauth, options);
+  });
+
+  afterAll(async function () {
+    await sdk.shutdown();
+  });
+
+  it("should has email field", async () => {
+    const profile = sdk.userProfile;
+    expect(profile.userId, "UserId should be present in user profile").eq(user.id);
+    expect(profile.email, "Email should be present in user profile").not.empty;
+  });
+});


### PR DESCRIPTION
Parse email from core.get-profile v1.0 response (CoreProfileV1) and expose it as readonly UserProfile.email.